### PR TITLE
fix: Resolve TypeScript error in wildcard route params

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -85,7 +85,7 @@ export function createServer(options: ServerOptions): ServerInstance {
 
   // GET /*.md - Serve markdown file as HTML (supports subdirectories)
   app.get('/*.md', (req, res) => {
-    const requestPath = req.params[0] + '.md';
+    const requestPath = req.path.slice(1);
     const validation = validateAndResolvePath(requestPath, publicDir);
 
     if (!validation.valid) {


### PR DESCRIPTION
## Summary
- `src/server.ts` の `req.params[0]` が Express のワイルドカードルートパラメータの型 `{ "": string[] }` に対して TS7053 エラーを引き起こしていた問題を修正
- `req.params[0]` の代わりに `req.path.slice(1)` を使用することで、型安全にリクエストパスを取得するように変更

## Test plan
- [x] `npm run typecheck` が正常に通ること
- [x] `npm run test:run` で全64テストが通ること
- [x] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)