### PR TITLE
feat: Add .gitignore-style file exclusion with .mdsignore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 
 This document contains the requirements for the issue number `[ISSUE-NUMBER]`, including the following sections:
 - Problem Statement
-- Requirements
+- Requirements(Functional and Non-Functional)
 - Constraints
 - Acceptance Criteria
 - User Stories

--- a/docs/012-gitignore-style-exclusion/design.md
+++ b/docs/012-gitignore-style-exclusion/design.md
@@ -1,0 +1,131 @@
+# Design: .gitignore-style File Exclusion (#12)
+
+## Architecture Overview
+
+A new `ignore-filter` module is introduced to handle loading and applying `.mdsignore` patterns. This module integrates into the existing file-scanning and request-handling pipelines.
+
+```mermaid
+graph TD
+    A[HTTP Request] --> B[Express Router]
+    B --> C["GET /"]
+    B --> D["GET /*.md"]
+    C --> E[scanMarkdownFiles]
+    E --> F[loadIgnoreFilter]
+    F --> G[Filter files]
+    G --> H[Return filtered list]
+    D --> I[validateAndResolvePath]
+    I --> J[loadIgnoreFilter]
+    J --> K{Is ignored?}
+    K -->|Yes| L[404 Not Found]
+    K -->|No| M[Serve markdown]
+```
+
+## Component Design
+
+### New Module: `src/ignore-filter.ts`
+
+This module provides two main functions:
+
+#### `loadIgnorePatterns(publicDir: string): string[]`
+
+- Reads the `.mdsignore` file from the root of `publicDir`.
+- Returns an array of pattern strings.
+- Returns an empty array if the file does not exist or cannot be read.
+
+#### `createIgnoreFilter(publicDir: string): (relativePath: string) => boolean`
+
+- Loads patterns using `loadIgnorePatterns`.
+- Uses the `ignore` npm package to compile patterns into a filter.
+- Returns a function `isIgnored(relativePath: string) => boolean`.
+- If no patterns exist, returns a function that always returns `false`.
+
+### Modified Module: `src/file-scanner.ts`
+
+- `scanMarkdownFiles` receives an optional ignore filter function parameter.
+- When provided, files matching the filter are excluded from the result.
+
+### Modified Module: `src/server.ts`
+
+- On `GET /`: Creates ignore filter and passes it to `scanMarkdownFiles`.
+- On `GET /*.md`: After path validation succeeds, checks if the file is ignored. If ignored, returns 404.
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant IgnoreFilter
+    participant FileScanner
+    participant FS as File System
+
+    Note over Client,FS: GET / - Index listing
+    Client->>Server: GET /
+    Server->>IgnoreFilter: createIgnoreFilter(publicDir)
+    IgnoreFilter->>FS: Read .mdsignore
+    FS-->>IgnoreFilter: patterns (or empty)
+    IgnoreFilter-->>Server: isIgnored function
+    Server->>FileScanner: scanMarkdownFiles(publicDir, isIgnored)
+    FileScanner->>FS: readdirSync (recursive)
+    FileScanner-->>Server: filtered MarkdownFile[]
+    Server-->>Client: HTML file list
+
+    Note over Client,FS: GET /*.md - Direct access
+    Client->>Server: GET /drafts/notes.md
+    Server->>Server: validateAndResolvePath
+    Server->>IgnoreFilter: createIgnoreFilter(publicDir)
+    IgnoreFilter->>FS: Read .mdsignore
+    FS-->>IgnoreFilter: patterns
+    IgnoreFilter-->>Server: isIgnored function
+    Server->>Server: isIgnored("drafts/notes.md")
+    alt File is ignored
+        Server-->>Client: 404 Not Found
+    else File is not ignored
+        Server->>FS: readFileSync
+        Server-->>Client: HTML content
+    end
+```
+
+## Domain Models
+
+### Ignore Filter
+
+```mermaid
+classDiagram
+    class IgnoreFilter {
+        +loadIgnorePatterns(publicDir: string): string[]
+        +createIgnoreFilter(publicDir: string): IsIgnoredFn
+    }
+
+    class IsIgnoredFn {
+        <<type alias>>
+        (relativePath: string) => boolean
+    }
+
+    class FileScanner {
+        +scanMarkdownFiles(publicDir: string, isIgnored?: IsIgnoredFn): MarkdownFile[]
+    }
+
+    IgnoreFilter --> IsIgnoredFn : creates
+    FileScanner --> IsIgnoredFn : uses
+```
+
+## Dependencies
+
+### New npm dependency: `ignore`
+
+- **Package**: [`ignore`](https://www.npmjs.com/package/ignore)
+- **Purpose**: Provides `.gitignore`-compatible pattern matching.
+- **Justification**: Well-tested, widely-used (used by ESLint, Prettier, etc.), and implements the full `.gitignore` specification including negation patterns, directory markers, and comments.
+- **Size**: Lightweight, no transitive dependencies.
+
+## File Changes Summary
+
+| File | Change |
+|---|---|
+| `src/ignore-filter.ts` | **New** - Ignore pattern loading and filter creation |
+| `src/file-scanner.ts` | **Modified** - Accept optional ignore filter |
+| `src/server.ts` | **Modified** - Integrate ignore filter in both routes |
+| `tests/ignore-filter.test.ts` | **New** - Tests for ignore filter module |
+| `tests/file-scanner.test.ts` | **Modified** - Tests for filtered scanning |
+| `tests/server.test.ts` | **Modified** - Tests for ignored file responses |

--- a/docs/012-gitignore-style-exclusion/requirements.md
+++ b/docs/012-gitignore-style-exclusion/requirements.md
@@ -1,0 +1,39 @@
+# Requirements: .gitignore-style File Exclusion (#12)
+
+## Problem Statement
+
+Currently, all `.md` files in the public directory are served without exception. Users cannot exclude specific files or directories (e.g., drafts, internal notes, `node_modules` documentation) from being published. There is no mechanism to control which markdown files are visible to visitors.
+
+## Requirements
+
+1. **Ignore File Support**: Users can create a `.mdsignore` file in the root of the public directory to specify exclusion patterns.
+2. **Gitignore Syntax**: The `.mdsignore` file uses the same pattern syntax as `.gitignore` (glob patterns, negation with `!`, directory patterns with `/`, comments with `#`).
+3. **Index Exclusion**: Files matching ignore patterns are excluded from the file listing on the index page (`GET /`).
+4. **Direct Access Exclusion**: Files matching ignore patterns return 404 when accessed directly via URL (`GET /:path.md`).
+5. **Nested Directory Support**: Patterns work correctly with files in nested subdirectories.
+6. **Backward Compatibility**: When no `.mdsignore` file exists, behavior is identical to the current implementation.
+7. **The `.mdsignore` file itself should not be served** (it is not a `.md` file, so this is already the case).
+
+## Constraints
+
+- The `.mdsignore` file must be placed in the root of the public directory.
+- Only one `.mdsignore` file is supported (no nested `.mdsignore` files in subdirectories).
+- The ignore file is read on each request (no caching) to support dynamic updates without server restart.
+- Pattern matching should be delegated to a well-tested library (e.g., the `ignore` npm package) rather than implementing custom pattern matching.
+
+## Acceptance Criteria
+
+- [ ] A `.mdsignore` file in the public directory root is recognized and parsed.
+- [ ] Patterns follow `.gitignore` syntax (glob patterns, `!` negation, `#` comments, `/` directory markers).
+- [ ] Matching files are excluded from the `GET /` index listing.
+- [ ] Matching files return 404 when accessed via `GET /:path.md`.
+- [ ] Patterns work for files in nested subdirectories.
+- [ ] When no `.mdsignore` file exists, all `.md` files are served as before.
+- [ ] When `.mdsignore` is empty, all `.md` files are served as before.
+
+## User Stories
+
+1. **As a user**, I want to create a `.mdsignore` file to exclude draft documents from being published, so that I can keep work-in-progress files private.
+2. **As a user**, I want to exclude entire directories (e.g., `drafts/`) from serving, so that all files within those directories are hidden.
+3. **As a user**, I want to use familiar `.gitignore` patterns, so that I don't need to learn a new syntax.
+4. **As a user**, I want the server to work normally when no `.mdsignore` file exists, so that existing setups are not affected.

--- a/docs/012-gitignore-style-exclusion/tasks.md
+++ b/docs/012-gitignore-style-exclusion/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: .gitignore-style File Exclusion (#12)
+
+## Implementation Tasks
+
+- [x] 1. Install the `ignore` npm package as a production dependency
+- [x] 2. Create `src/ignore-filter.ts` with `loadIgnorePatterns` and `createIgnoreFilter` functions (TDD)
+- [x] 3. Modify `src/file-scanner.ts` to accept an optional ignore filter function (TDD)
+- [x] 4. Modify `src/server.ts` to integrate the ignore filter in `GET /` and `GET /*.md` routes (TDD)
+- [x] 5. Run full test suite to confirm all existing and new tests pass
+- [x] 6. Run type checking to confirm no type errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "md-server",
+  "name": "@satoryu/md-server",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "md-server",
+      "name": "@satoryu/md-server",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -13,6 +13,7 @@
         "commander": "^12.0.0",
         "express": "^4.21.0",
         "highlight.js": "^11.11.1",
+        "ignore": "^7.0.5",
         "marked": "^15.0.0"
       },
       "bin": {
@@ -1848,6 +1849,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/inherits": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "commander": "^12.0.0",
     "express": "^4.21.0",
     "highlight.js": "^11.11.1",
+    "ignore": "^7.0.5",
     "marked": "^15.0.0"
   },
   "devDependencies": {

--- a/src/file-scanner.ts
+++ b/src/file-scanner.ts
@@ -21,7 +21,7 @@ export interface MarkdownFile {
  * @param publicDir - The root directory to scan
  * @returns Array of MarkdownFile objects
  */
-export function scanMarkdownFiles(publicDir: string): MarkdownFile[] {
+export function scanMarkdownFiles(publicDir: string, isIgnored?: (relativePath: string) => boolean): MarkdownFile[] {
   const files: MarkdownFile[] = [];
 
   try {
@@ -35,6 +35,10 @@ export function scanMarkdownFiles(publicDir: string): MarkdownFile[] {
         const absolutePath = join(parentPath, entry.name);
         const relativePath = relative(publicDir, absolutePath);
         const directory = dirname(relativePath);
+
+        if (isIgnored && isIgnored(relativePath)) {
+          continue;
+        }
 
         files.push({
           relativePath,

--- a/src/ignore-filter.ts
+++ b/src/ignore-filter.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ignore from 'ignore';
+
+const IGNORE_FILENAME = '.mdsignore';
+
+/**
+ * Loads ignore patterns from a .mdsignore file in the given directory.
+ *
+ * @param publicDir - The root directory to look for .mdsignore
+ * @returns Array of pattern strings (empty if file doesn't exist)
+ */
+export function loadIgnorePatterns(publicDir: string): string[] {
+  try {
+    const content = readFileSync(join(publicDir, IGNORE_FILENAME), 'utf-8');
+    return content
+      .split('\n')
+      .filter((line) => line.trim() !== '' && !line.startsWith('#'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Creates a filter function that checks if a relative path should be ignored.
+ *
+ * @param publicDir - The root directory to look for .mdsignore
+ * @returns A function that returns true if the given relative path is ignored
+ */
+export function createIgnoreFilter(publicDir: string): (relativePath: string) => boolean {
+  const patterns = loadIgnorePatterns(publicDir);
+  if (patterns.length === 0) {
+    return () => false;
+  }
+
+  const ig = ignore().add(patterns);
+  return (relativePath: string) => ig.ignores(relativePath);
+}

--- a/tests/file-scanner.test.ts
+++ b/tests/file-scanner.test.ts
@@ -100,4 +100,25 @@ describe('scanMarkdownFiles', () => {
     expect(readmeFile).toBeDefined();
     expect(readmeFile?.directory).toBe('');
   });
+
+  it('should exclude files matched by ignore filter', () => {
+    const isIgnored = (relativePath: string) => relativePath === 'README.md' || relativePath.startsWith('docs/');
+    const files = scanMarkdownFiles(testDir, isIgnored);
+    const relativePaths = files.map((f) => f.relativePath);
+
+    expect(relativePaths).not.toContain('README.md');
+    expect(relativePaths).not.toContain('docs/guide.md');
+    expect(relativePaths).not.toContain('docs/api.md');
+    expect(relativePaths).toContain('index.md');
+    expect(relativePaths).toContain('guides/advanced/deep.md');
+  });
+
+  it('should return all files when no ignore filter is provided', () => {
+    const files = scanMarkdownFiles(testDir);
+    const relativePaths = files.map((f) => f.relativePath);
+
+    expect(relativePaths).toContain('README.md');
+    expect(relativePaths).toContain('docs/guide.md');
+    expect(relativePaths).toContain('guides/advanced/deep.md');
+  });
 });

--- a/tests/ignore-filter.test.ts
+++ b/tests/ignore-filter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadIgnorePatterns, createIgnoreFilter } from '../src/ignore-filter.js';
+
+describe('loadIgnorePatterns', () => {
+  const baseTmpDir = realpathSync(tmpdir());
+  const testDir = join(baseTmpDir, 'md-server-ignore-patterns-test-' + Date.now());
+
+  beforeAll(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should return an empty array when .mdsignore does not exist', () => {
+    const patterns = loadIgnorePatterns(testDir);
+    expect(patterns).toEqual([]);
+  });
+
+  it('should return patterns from .mdsignore file', () => {
+    const dir = join(testDir, 'with-ignore');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), 'drafts/\nsecret.md\n');
+
+    const patterns = loadIgnorePatterns(dir);
+    expect(patterns).toEqual(['drafts/', 'secret.md']);
+  });
+
+  it('should ignore comments and empty lines', () => {
+    const dir = join(testDir, 'with-comments');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), '# This is a comment\n\ndrafts/\n\n# Another comment\nsecret.md\n');
+
+    const patterns = loadIgnorePatterns(dir);
+    expect(patterns).toEqual(['drafts/', 'secret.md']);
+  });
+
+  it('should return an empty array for an empty .mdsignore file', () => {
+    const dir = join(testDir, 'empty-ignore');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), '');
+
+    const patterns = loadIgnorePatterns(dir);
+    expect(patterns).toEqual([]);
+  });
+});
+
+describe('createIgnoreFilter', () => {
+  const baseTmpDir = realpathSync(tmpdir());
+  const testDir = join(baseTmpDir, 'md-server-ignore-filter-test-' + Date.now());
+
+  beforeAll(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should return a function that always returns false when no .mdsignore exists', () => {
+    const isIgnored = createIgnoreFilter(testDir);
+    expect(isIgnored('README.md')).toBe(false);
+    expect(isIgnored('docs/guide.md')).toBe(false);
+  });
+
+  it('should ignore files matching exact filename patterns', () => {
+    const dir = join(testDir, 'exact');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), 'secret.md\n');
+
+    const isIgnored = createIgnoreFilter(dir);
+    expect(isIgnored('secret.md')).toBe(true);
+    expect(isIgnored('README.md')).toBe(false);
+  });
+
+  it('should ignore files matching directory patterns', () => {
+    const dir = join(testDir, 'directory');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), 'drafts/\n');
+
+    const isIgnored = createIgnoreFilter(dir);
+    expect(isIgnored('drafts/notes.md')).toBe(true);
+    expect(isIgnored('drafts/deep/nested.md')).toBe(true);
+    expect(isIgnored('published/notes.md')).toBe(false);
+  });
+
+  it('should ignore files matching glob patterns', () => {
+    const dir = join(testDir, 'glob');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), 'TODO-*.md\n');
+
+    const isIgnored = createIgnoreFilter(dir);
+    expect(isIgnored('TODO-2024.md')).toBe(true);
+    expect(isIgnored('TODO-feature.md')).toBe(true);
+    expect(isIgnored('README.md')).toBe(false);
+  });
+
+  it('should support negation patterns', () => {
+    const dir = join(testDir, 'negation');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), '*.md\n!important.md\n');
+
+    const isIgnored = createIgnoreFilter(dir);
+    expect(isIgnored('notes.md')).toBe(true);
+    expect(isIgnored('important.md')).toBe(false);
+  });
+
+  it('should return false for all files when .mdsignore is empty', () => {
+    const dir = join(testDir, 'empty');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, '.mdsignore'), '');
+
+    const isIgnored = createIgnoreFilter(dir);
+    expect(isIgnored('README.md')).toBe(false);
+    expect(isIgnored('docs/guide.md')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `.mdsignore` file support using `.gitignore` syntax to exclude files/directories from serving
- Excluded files are hidden from the index listing (`GET /`) and return 404 on direct access (`GET /*.md`)
- Uses the `ignore` npm package for pattern matching (same library used by ESLint, Prettier, etc.)

Closes #12

## Changes

| File | Description |
|---|---|
| `src/ignore-filter.ts` | New module: loads `.mdsignore` patterns and creates filter function |
| `src/file-scanner.ts` | Accept optional ignore filter to exclude matched files |
| `src/server.ts` | Integrate ignore filter in both `GET /` and `GET /*.md` routes |
| `tests/ignore-filter.test.ts` | 10 tests for ignore filter module |
| `tests/file-scanner.test.ts` | 2 new tests for filtered scanning |
| `tests/server.test.ts` | 7 new tests for server integration |

## Test plan

- [x] Ignore filter correctly parses `.mdsignore` patterns (comments, empty lines, globs, negation)
- [x] File scanner excludes matching files when filter is provided
- [x] Server index page excludes ignored files from listing
- [x] Server returns 404 for directly accessed ignored files
- [x] Backward compatibility: no behavior change when `.mdsignore` is absent
- [x] All 99 tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)